### PR TITLE
exchang_transaction changes 

### DIFF
--- a/lib/exchange_transaction.js
+++ b/lib/exchange_transaction.js
@@ -10,7 +10,7 @@ var errors = require('./errors');
 /**
  * If any synchronous JSON-RPC request fails, UNKNOWN_ERROR should be thrown
  */
-var transactions = function (config, hash, logIndex, callback) {
+var transactions = function (config, identifier, hash, callback) {
     try {
 
         // setup configurable properties
@@ -18,14 +18,22 @@ var transactions = function (config, hash, logIndex, callback) {
 
         // start web3.js
         web3.setProvider(new web3.providers.HttpProvider('http://' + config.jsonrpc_host + ':' + config.jsonrpc_port));
+        if (!utils.validateIdentifier(identifier)) {
+            return callback(errors.IDENTIFIER_IS_INCORRECT);
+        }
+
+        // validate exchange identifier
+        var address = namereg.addr(identifier);
+        if (utils.isEmptyAddress(address)) {
+            return callback(errors.IDENTIFIER_NO_ADDRESS);
+        }
     
         var transaction = web3.eth.getTransactionReceipt(hash);
         
         // we have to filter logs, cause this transaction could also trigger logs in other contracts
-        var log = transaction.logs.filter(function (l) {
-            // allow to loosely match. use ==, instead of === 
-            return l.logIndex == logIndex;
-        })[0];
+        var logs = transaction.logs.filter(function (l) {
+            return l.address = address;
+        });
         
         callback(null, log);
 

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -132,15 +132,15 @@ var balance = function (config, identifier, callback) {
  *
  * @method transaction
  * @param {Object} config
+ * @param {Number} identifier of institution
  * @param {String} hash, transactionHash - TODO
- * @param {Number} logIndex, index of log
  * @param {Function} callback triggered on result
  * @throws UNKNOWN_ERROR
  * @throws IDENTIFIER_IS_INCORRECT
  * @throws IDENTIFIER_NO_ADDRESS
  */
-var transaction = function (config, hash, logIndex, callback) {
-    runInProcess(extTransaction, [config, hash, logIndex], callback);
+var transaction = function (config, identifier, hash callback) {
+    runInProcess(extTransaction, [config, identifier, hash], callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-exchange",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "",
   "main": "./lib/interface.js",
   "bin": "./app.js",


### PR DESCRIPTION
# changes
- `exchange_transaction` should be queried with exchange 'identifier'.
- `exchange_transaction` returns an array instead of object.
- `exchange_transaction` request:
  
  ``` diff
  -curl -X POST --data '{"id":8,"jsonrpc":"2.0","method":"exchange_transaction","params":["0xacf64bd586a847523086882c82c4cff6d77b1a753ea28c164046e37f3606583c", 0]}' -H "Content-Type: application/json" http://localhost:8545
  +curl -X POST --data '{"id":8,"jsonrpc":"2.0","method":"exchange_transaction","params":["XROF", "0xacf64bd586a847523086882c82c4cff6d77b1a753ea28c164046e37f3606583c"]}' -H "Content-Type: application/json" http://localhost:8545
  ```
  
  ``` diff
  {
  "id": 8,
  "jsonrpc": "2.0",
  "method": "exchange_transaction",
  "params": [
  -    "0xacf64bd586a847523086882c82c4cff6d77b1a753ea28c164046e37f3606583c",
  -    0
  +    "XROF",
  +    "0xacf64bd586a847523086882c82c4cff6d77b1a753ea28c164046e37f3606583c"
  ]
  }
  ```
- `exchange_transaction` response:
  
  ``` diff
  {
  "jsonrpc": "2.0",
  "id": 8,
  - "result": {
  + "result": [{
    "address": "0x9b173b6fab888af1b5eff49bf34c7aaebf58673f",
    "blockNumber": 55,
    "logIndex": 0,
    "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "transactionHash": "0xacf64bd586a847523086882c82c4cff6d77b1a753ea28c164046e37f3606583c",
    "transactionIndex": 0,
    "event": "Deposit",
    "args": {
      "from": "0x275ac21e0b9383dcc0fa0fc4ecf7bf1ec7c4bba9",
      "to": "0x4d4152454b4f464b4b0000000000000000000000000000000000000000000000",
      "value": "15000"
    }
  -}
  +}]
  }
  ```
# explanation

`exchange transactions` are logs created by contracts and stored on the blockchain. Sometimes 1 transaction can create more than 1 log. That's why we need to return an array.
