### PR TITLE
Added the emit key word for the Event Logger

### DIFF
--- a/lib/contracts/SmartExchange.sol
+++ b/lib/contracts/SmartExchange.sol
@@ -8,21 +8,21 @@ contract SmartExchange is owned {
 	event IcapTransfer(bytes32 indexed from, address indexed to, bytes32 indirectId, uint value);
 
 	function () {
-		AnonymousDeposit(msg.sender, msg.value);
+		emit AnonymousDeposit(msg.sender, msg.value);
 	}
 
 	function deposit(bytes32 to) {
-		Deposit(msg.sender, to, msg.value);
+		emit Deposit(msg.sender, to, msg.value);
 	}
 
 	function transfer(bytes32 from, address to, uint value) onlyowner {
 		to.send(value);
-		Transfer(from, to, value);
+		emit Transfer(from, to, value);
 	}
 
 	function icapTransfer(bytes32 from, address to, bytes32 indirectId, uint value) onlyowner {
 		SmartExchange(to).deposit.value(value)(indirectId); // value?
-		IcapTransfer(from, to, indirectId, value);
+		emit IcapTransfer(from, to, indirectId, value);
 	}
 }
 


### PR DESCRIPTION
Added the `emit` keyword for the Event Logger, I discovered it was omitted so I was going through the documentation and I found out that is required.